### PR TITLE
chore(tests): add test for Notifier

### DIFF
--- a/internal/notifications/notification_test.go
+++ b/internal/notifications/notification_test.go
@@ -1,0 +1,51 @@
+package notifications
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hbk619/gh-peruse/internal/requests"
+	"github.com/stretchr/testify/suite"
+)
+
+type NotifierSuite struct {
+	suite.Suite
+	ctrl            *gomock.Controller
+	originalNotify func(contents string, command requests.CommandLine) error
+	Notifier       *Notifier
+}
+
+func (suite *NotifierSuite) BeforeTest(string, string) {
+	suite.ctrl = gomock.NewController(suite.T())
+	suite.originalNotify = Notify
+	suite.Notifier = NewNotifier()
+}
+
+func (suite *NotifierSuite) AfterTest(string, string) {
+	Notify = suite.originalNotify
+}
+
+func (suite *NotifierSuite) TestWrite_calls_write_to() {
+	actualContents := ""
+	Notify = func(contents string, command requests.CommandLine) error {
+		actualContents = contents
+		return nil
+	}
+	err := suite.Notifier.Println("test")
+	suite.NoError(err)
+	suite.Equal("test", actualContents)
+}
+
+func (suite *NotifierSuite) TestWrite_returns_error() {
+	expectedErr := errors.New("oops")
+	Notify = func(contents string, command requests.CommandLine) error {
+		return expectedErr
+	}
+	actualErr := suite.Notifier.Println("test")
+	suite.ErrorIs(actualErr, expectedErr)
+}
+
+func TestNotifierSuite(t *testing.T) {
+	suite.Run(t, new(NotifierSuite))
+}

--- a/internal/notifications/notify_linux.go
+++ b/internal/notifications/notify_linux.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hbk619/gh-peruse/internal/requests"
 )
 
-func Notify(message string, command requests.CommandLine) error {
+var Notify = func(message string, command requests.CommandLine) error {
 	result, err := command.Run("notify-send", []string{message})
 	if err != nil {
 		return err

--- a/internal/notifications/notify_linux_test.go
+++ b/internal/notifications/notify_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package notifications
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mock_requests "github.com/hbk619/gh-peruse/internal/requests/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type NotifyLinuxSuite struct {
+	suite.Suite
+	ctrl            *gomock.Controller
+	mockCommandLine *mock_requests.MockCommandLine
+}
+
+func (suite *NotifyLinuxSuite) BeforeTest(string, string) {
+	suite.ctrl = gomock.NewController(suite.T())
+	suite.mockCommandLine = mock_requests.NewMockCommandLine(suite.ctrl)
+}
+
+func (suite *NotifyLinuxSuite) TestNotify_sends_msg() {
+	suite.mockCommandLine.EXPECT().Run("notify-send", []string{"test"}).Return("", nil)
+	Notify("test", suite.mockCommandLine)
+}
+
+func TestNotifyLinuxSuiteSuite(t *testing.T) {
+	suite.Run(t, new(NotifyLinuxSuite))
+}

--- a/internal/notifications/notify_mac.go
+++ b/internal/notifications/notify_mac.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hbk619/gh-peruse/internal/requests"
 )
 
-func Notify(message string, command requests.CommandLine) error {
+var Notify = func(message string, command requests.CommandLine) error {
 	result, err := command.Run("osascript", []string{"-e", fmt.Sprintf("display notification \"%s\"", message)})
 	if err != nil {
 		return err

--- a/internal/notifications/notify_windows.go
+++ b/internal/notifications/notify_windows.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hbk619/gh-peruse/internal/requests"
 )
 
-func Notify(message string, command requests.CommandLine) error {
+var Notify = func(message string, command requests.CommandLine) error {
 	result, err := command.Run("msg", []string{"*", "/TIME:3", message})
 	if err != nil {
 		return err


### PR DESCRIPTION
By changing the Notify func to a var we can override it in the test and test the Notifier. Not the nicest pattern but does let us have some confidence it does what we hope.